### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [0.1.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.1.0...0.1.1) - 2026-03-23
+
+### 🐛 Bug Fixes
+
+- Compare SHA1 of source file in check_for_update - ([6f46a5b](https://github.com/pkgforge-dev/AppImageUpdate/commit/6f46a5bf4bbc68dd93a2d4a3c3d637231d1f8102))
+- Make -O flag overwrite source file in-place - ([6644b33](https://github.com/pkgforge-dev/AppImageUpdate/commit/6644b3306c22a4ce40bc1096cf2a07c2906752f7))
+
 ## [0.1.0] - 2026-03-23
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimageupdate"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimageupdate"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Fast, bandwidth-efficient AppImage updater using zsync"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `appimageupdate`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.1.0...0.1.1) - 2026-03-23

### 🐛 Bug Fixes

- Compare SHA1 of source file in check_for_update - ([6f46a5b](https://github.com/pkgforge-dev/AppImageUpdate/commit/6f46a5bf4bbc68dd93a2d4a3c3d637231d1f8102))
- Make -O flag overwrite source file in-place - ([6644b33](https://github.com/pkgforge-dev/AppImageUpdate/commit/6644b3306c22a4ce40bc1096cf2a07c2906752f7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).