### PR TITLE
add support for more config file locations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,17 +56,39 @@ pub fn get() -> &'static Config {
 }
 
 fn load_config() -> Config {
-    let config_path = dirs::config_dir().map(|p| p.join("appimageupdate").join("config.toml"));
-
-    let config_path = match config_path {
-        Some(p) if p.exists() => p,
-        _ => return Config::default(),
-    };
-
-    match std::fs::read_to_string(&config_path) {
-        Ok(content) => toml::from_str(&content).unwrap_or_default(),
-        Err(_) => Config::default(),
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let portable = dir.join("config.toml");
+            if portable.exists() {
+                if let Ok(content) = std::fs::read_to_string(&portable) {
+                    if let Ok(config) = toml::from_str(&content) {
+                        return config;
+                    }
+                }
+            }
+        }
     }
+
+    if let Some(user_config) = dirs::config_dir().map(|p| p.join("appimageupdate").join("config.toml")) {
+        if user_config.exists() {
+            if let Ok(content) = std::fs::read_to_string(&user_config) {
+                if let Ok(config) = toml::from_str(&content) {
+                    return config;
+                }
+            }
+        }
+    }
+
+    let global_config = PathBuf::from("/etc/appimageupdate/config.toml");
+    if global_config.exists() {
+        if let Ok(content) = std::fs::read_to_string(&global_config) {
+            if let Ok(config) = toml::from_str(&content) {
+                return config;
+            }
+        }
+    }
+
+    Config::default()
 }
 
 pub fn get_proxies() -> Vec<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,31 +56,27 @@ pub fn get() -> &'static Config {
 }
 
 fn load_config() -> Config {
-    let portable = std::env::current_exe()
-        .ok()
-        .and_then(|exe| exe.parent().map(|dir| dir.join("config.toml")));
+    let portable = std::env::current_exe().ok().and_then(|exe| {
+        let dir = exe.parent()?;
+        let name = exe.file_stem()?.to_str()?;
+        Some(dir.join(format!("{name}.toml")))
+    });
 
-    let user_config = dirs::config_dir().map(|p| p.join("appimageupdate").join("config.toml"));
+    let user = dirs::config_dir().map(|p| p.join("appimageupdate/config.toml"));
 
-    let global_config = PathBuf::from("/etc/appimageupdate/config.toml");
+    let global = Some(PathBuf::from("/etc/appimageupdate/config.toml"));
 
-    for path in portable
-        .iter()
-        .chain(user_config.iter())
-        .chain(Some(&global_config))
-    {
-        if let Some(config) = try_load_config(path) {
-            return config;
-        }
-    }
-
-    Config::default()
+    portable
+        .into_iter()
+        .chain(user)
+        .chain(global)
+        .find_map(try_load_config)
+        .unwrap_or_default()
 }
 
-fn try_load_config(path: &PathBuf) -> Option<Config> {
-    path.exists()
-        .then(|| std::fs::read_to_string(path).ok())
-        .flatten()
+fn try_load_config(path: PathBuf) -> Option<Config> {
+    std::fs::read_to_string(&path)
+        .ok()
         .and_then(|content| toml::from_str(&content).ok())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,39 +56,32 @@ pub fn get() -> &'static Config {
 }
 
 fn load_config() -> Config {
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let portable = dir.join("config.toml");
-            if portable.exists() {
-                if let Ok(content) = std::fs::read_to_string(&portable) {
-                    if let Ok(config) = toml::from_str(&content) {
-                        return config;
-                    }
-                }
-            }
-        }
-    }
+    let portable = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(|dir| dir.join("config.toml")));
 
-    if let Some(user_config) = dirs::config_dir().map(|p| p.join("appimageupdate").join("config.toml")) {
-        if user_config.exists() {
-            if let Ok(content) = std::fs::read_to_string(&user_config) {
-                if let Ok(config) = toml::from_str(&content) {
-                    return config;
-                }
-            }
-        }
-    }
+    let user_config = dirs::config_dir().map(|p| p.join("appimageupdate").join("config.toml"));
 
     let global_config = PathBuf::from("/etc/appimageupdate/config.toml");
-    if global_config.exists() {
-        if let Ok(content) = std::fs::read_to_string(&global_config) {
-            if let Ok(config) = toml::from_str(&content) {
-                return config;
-            }
+
+    for path in portable
+        .iter()
+        .chain(user_config.iter())
+        .chain(Some(&global_config))
+    {
+        if let Some(config) = try_load_config(path) {
+            return config;
         }
     }
 
     Config::default()
+}
+
+fn try_load_config(path: &PathBuf) -> Option<Config> {
+    path.exists()
+        .then(|| std::fs::read_to_string(path).ok())
+        .flatten()
+        .and_then(|content| toml::from_str(&content).ok())
 }
 
 pub fn get_proxies() -> Vec<String> {


### PR DESCRIPTION
* if there is a `config.toml` next to the binary it uses that. 

* falls back to the current config file in `XDG_CONFIG_HOME` logic.

* extra fallback to `/etc` for a global config file was added as well.