### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 
+## [0.2.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.1.1...0.2.0) - 2026-03-24
+
+### ⛰️  Features
+
+- Add progress display during updates - ([90233e1](https://github.com/pkgforge-dev/AppImageUpdate/commit/90233e1b05d2e68a998cec4a383f992b453496d1))
+- Add support for updating multiple AppImages at once - ([c59368d](https://github.com/pkgforge-dev/AppImageUpdate/commit/c59368d4e81df1e31c0a3be57d42bcdb07baa1ae))
+- Add global and portable config file support ([#5](https://github.com/pkgforge-dev/AppImageUpdate/pull/5)) - ([2db70c8](https://github.com/pkgforge-dev/AppImageUpdate/commit/2db70c8b35eeb950ee3aa87860d0eb67db0f8466))
+
+### 🐛 Bug Fixes
+
+- Handle backup file removal - ([73d4ba5](https://github.com/pkgforge-dev/AppImageUpdate/commit/73d4ba5cf6d711418cbafca744dcb002c01b6489))
+
+### 📚 Documentation
+
+- Update README ([#4](https://github.com/pkgforge-dev/AppImageUpdate/pull/4)) - ([0c72d84](https://github.com/pkgforge-dev/AppImageUpdate/commit/0c72d84d3b7a18c2f759204ae7a5241d2778f9f5))
+
 ## [0.1.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.1.0...0.1.1) - 2026-03-23
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimageupdate"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimageupdate"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "Fast, bandwidth-efficient AppImage updater using zsync"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `appimageupdate`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `appimageupdate` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field UpdateStats.backup_path in /tmp/.tmpVqekTT/AppImageUpdate/src/updater.rs:27
  field UpdateStats.backup_path in /tmp/.tmpVqekTT/AppImageUpdate/src/updater.rs:27
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.1.1...0.2.0) - 2026-03-24

### ⛰️  Features

- Add progress display during updates - ([90233e1](https://github.com/pkgforge-dev/AppImageUpdate/commit/90233e1b05d2e68a998cec4a383f992b453496d1))
- Add support for updating multiple AppImages at once - ([c59368d](https://github.com/pkgforge-dev/AppImageUpdate/commit/c59368d4e81df1e31c0a3be57d42bcdb07baa1ae))
- Add global and portable config file support ([#5](https://github.com/pkgforge-dev/AppImageUpdate/pull/5)) - ([2db70c8](https://github.com/pkgforge-dev/AppImageUpdate/commit/2db70c8b35eeb950ee3aa87860d0eb67db0f8466))

### 🐛 Bug Fixes

- Handle backup file removal - ([73d4ba5](https://github.com/pkgforge-dev/AppImageUpdate/commit/73d4ba5cf6d711418cbafca744dcb002c01b6489))

### 📚 Documentation

- Update README ([#4](https://github.com/pkgforge-dev/AppImageUpdate/pull/4)) - ([0c72d84](https://github.com/pkgforge-dev/AppImageUpdate/commit/0c72d84d3b7a18c2f759204ae7a5241d2778f9f5))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).