### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [0.2.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.2.0...0.2.1) - 2026-03-25
+
+### ⛰️  Features
+
+- Support checking updates for multiple AppImages - ([a50f175](https://github.com/pkgforge-dev/AppImageUpdate/commit/a50f175c8b87163372b2533e8df1d5d7e6affc31))
+- Add `GITHUB_TOKEN` support ([#9](https://github.com/pkgforge-dev/AppImageUpdate/pull/9)) - ([e9247f6](https://github.com/pkgforge-dev/AppImageUpdate/commit/e9247f6d048f19604568768fd54448fa0dcc4673))
+
 ## [0.2.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.1.1...0.2.0) - 2026-03-24
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimageupdate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimageupdate"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Fast, bandwidth-efficient AppImage updater using zsync"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `appimageupdate`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.2.0...0.2.1) - 2026-03-25

### ⛰️  Features

- Support checking updates for multiple AppImages - ([a50f175](https://github.com/pkgforge-dev/AppImageUpdate/commit/a50f175c8b87163372b2533e8df1d5d7e6affc31))
- Add `GITHUB_TOKEN` support ([#9](https://github.com/pkgforge-dev/AppImageUpdate/pull/9)) - ([e9247f6](https://github.com/pkgforge-dev/AppImageUpdate/commit/e9247f6d048f19604568768fd54448fa0dcc4673))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).