### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 
+## [0.3.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.2.1...0.3.0) - 2026-04-14
+
+### ⛰️  Features
+
+- Add Forgejo support as alias for Gitea - ([886efa2](https://github.com/pkgforge-dev/AppImageUpdate/commit/886efa245c22d61a668a748b8f8df0c8c3ad3e21))
+- Add --list-releases to show available versions - ([78d3b89](https://github.com/pkgforge-dev/AppImageUpdate/commit/78d3b892740b38043f34dada05dd72dcd51713f3))
+- Add --target-tag for version targeting and downgrade - ([513e522](https://github.com/pkgforge-dev/AppImageUpdate/commit/513e522aefabe2609442e2f0bb69c7b42f116d1f))
+- Add API proxy support for GitLab and Codeberg - ([0e802af](https://github.com/pkgforge-dev/AppImageUpdate/commit/0e802afbcdf968fbde292b6dec41bcba5f2d11bd))
+- Add Codeberg and Gitea update info support - ([5d85807](https://github.com/pkgforge-dev/AppImageUpdate/commit/5d85807198cd123461c33649a5dac50ddbda2783))
+- Add GitLab update info support - ([c20dc30](https://github.com/pkgforge-dev/AppImageUpdate/commit/c20dc30fb618b0303cd3691bad3388d7de51087d))
+- Parallel AppImage updates with progress bars - ([9d0da26](https://github.com/pkgforge-dev/AppImageUpdate/commit/9d0da26d808157a9630f50d8d47c6cb3e7127bc3))
+
+### 🚜 Refactor
+
+- Use releasekit for GitHub release fetching - ([ad1465c](https://github.com/pkgforge-dev/AppImageUpdate/commit/ad1465c4bc64e636f4372d20a38eff5a512ef472))
+
+### 📚 Documentation
+
+- Update README - ([e801527](https://github.com/pkgforge-dev/AppImageUpdate/commit/e801527310c2047e3f9283e64bf1485c36317495))
+- Update README with multi-forge support - ([52c02f8](https://github.com/pkgforge-dev/AppImageUpdate/commit/52c02f8291eb7324a42c1b14f23bb9fe61c1dde3))
+- Update README - ([029a364](https://github.com/pkgforge-dev/AppImageUpdate/commit/029a364a7489dc4b54dc4ea7f56797148e757cb7))
+
 ## [0.2.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.2.0...0.2.1) - 2026-03-25
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimageupdate"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimageupdate"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "Fast, bandwidth-efficient AppImage updater using zsync"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `appimageupdate`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `appimageupdate` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Updater is no longer UnwindSafe, in /tmp/.tmpF8Hpfz/AppImageUpdate/src/updater.rs:47
  type Updater is no longer UnwindSafe, in /tmp/.tmpF8Hpfz/AppImageUpdate/src/updater.rs:47

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.gitlab_api_proxy in /tmp/.tmpF8Hpfz/AppImageUpdate/src/config.rs:31
  field Config.codeberg_api_proxy in /tmp/.tmpF8Hpfz/AppImageUpdate/src/config.rs:32

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:ForgeApi in /tmp/.tmpF8Hpfz/AppImageUpdate/src/error.rs:15
  variant Error:ForgeApi in /tmp/.tmpF8Hpfz/AppImageUpdate/src/error.rs:15

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::GitHubApi, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/error.rs:15
  variant Error::GitHubApi, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/error.rs:15

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function appimageupdate::config::get_proxies, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/config.rs:83
  function appimageupdate::config::set_proxies, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/config.rs:43
  function appimageupdate::config::build_api_url, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/config.rs:135

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Updater::source_size, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/updater.rs:144
  Updater::output_path, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/updater.rs:292
  Updater::progress, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/updater.rs:297
  Updater::source_size, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/updater.rs:144
  Updater::output_path, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/updater.rs:292
  Updater::progress, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/updater.rs:297

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct appimageupdate::update_info::GitHubUpdateInfo, previously in file /tmp/.tmp2bdKEU/appimageupdate/src/update_info/github.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.2.1...0.3.0) - 2026-04-14

### ⛰️  Features

- Add Forgejo support as alias for Gitea - ([886efa2](https://github.com/pkgforge-dev/AppImageUpdate/commit/886efa245c22d61a668a748b8f8df0c8c3ad3e21))
- Add --list-releases to show available versions - ([78d3b89](https://github.com/pkgforge-dev/AppImageUpdate/commit/78d3b892740b38043f34dada05dd72dcd51713f3))
- Add --target-tag for version targeting and downgrade - ([513e522](https://github.com/pkgforge-dev/AppImageUpdate/commit/513e522aefabe2609442e2f0bb69c7b42f116d1f))
- Add API proxy support for GitLab and Codeberg - ([0e802af](https://github.com/pkgforge-dev/AppImageUpdate/commit/0e802afbcdf968fbde292b6dec41bcba5f2d11bd))
- Add Codeberg and Gitea update info support - ([5d85807](https://github.com/pkgforge-dev/AppImageUpdate/commit/5d85807198cd123461c33649a5dac50ddbda2783))
- Add GitLab update info support - ([c20dc30](https://github.com/pkgforge-dev/AppImageUpdate/commit/c20dc30fb618b0303cd3691bad3388d7de51087d))
- Parallel AppImage updates with progress bars - ([9d0da26](https://github.com/pkgforge-dev/AppImageUpdate/commit/9d0da26d808157a9630f50d8d47c6cb3e7127bc3))

### 🚜 Refactor

- Use releasekit for GitHub release fetching - ([ad1465c](https://github.com/pkgforge-dev/AppImageUpdate/commit/ad1465c4bc64e636f4372d20a38eff5a512ef472))

### 📚 Documentation

- Update README - ([e801527](https://github.com/pkgforge-dev/AppImageUpdate/commit/e801527310c2047e3f9283e64bf1485c36317495))
- Update README with multi-forge support - ([52c02f8](https://github.com/pkgforge-dev/AppImageUpdate/commit/52c02f8291eb7324a42c1b14f23bb9fe61c1dde3))
- Update README - ([029a364](https://github.com/pkgforge-dev/AppImageUpdate/commit/029a364a7489dc4b54dc4ea7f56797148e757cb7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).