### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [0.3.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.3.0...0.3.1) - 2026-04-14
+
+### 🐛 Bug Fixes
+
+- Improve error messages with project context - ([9bfdfd9](https://github.com/pkgforge-dev/AppImageUpdate/commit/9bfdfd9ce55caed710f18c7c8afc4ff5a4eb308d))
+- Handle full URL in Gitea/Forgejo instance field - ([0683fbf](https://github.com/pkgforge-dev/AppImageUpdate/commit/0683fbf1deee5623c3f7cffef2dce20f6bc17430))
+
 ## [0.3.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.2.1...0.3.0) - 2026-04-14
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "appimageupdate"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimageupdate"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Fast, bandwidth-efficient AppImage updater using zsync"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `appimageupdate`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.3.0...0.3.1) - 2026-04-14

### 🐛 Bug Fixes

- Improve error messages with project context - ([9bfdfd9](https://github.com/pkgforge-dev/AppImageUpdate/commit/9bfdfd9ce55caed710f18c7c8afc4ff5a4eb308d))
- Handle full URL in Gitea/Forgejo instance field - ([0683fbf](https://github.com/pkgforge-dev/AppImageUpdate/commit/0683fbf1deee5623c3f7cffef2dce20f6bc17430))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).