### PR TITLE
ci: build riscv64, loongarch64, and ppc64 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,16 @@ jobs:
 
       - name: Build
         run: |
+          # the profile only asks for panic = "abort" so the crate still builds
+          # on stable; nightly upgrades it to immediate-abort here
+          export RUSTFLAGS="-Z unstable-options -C panic=immediate-abort"
           if [ -n "${{ matrix.build.ZIGTARGET }}" ]; then
             TARGET_ENV=$(echo "${{ matrix.build.TARGET }}" | tr 'a-z-' 'A-Z_')
             CC_ENV=$(echo "${{ matrix.build.TARGET }}" | tr '-' '_')
             export CARGO_TARGET_${TARGET_ENV}_LINKER="$RUNNER_TEMP/zigcc"
             export CC_${CC_ENV}="$RUNNER_TEMP/zigcc"
             export AR_${CC_ENV}="$RUNNER_TEMP/zigar"
-            export RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=no"
+            RUSTFLAGS="$RUSTFLAGS -C target-feature=+crt-static -C link-self-contained=no"
             export ZIG_GLOBAL_CACHE_DIR="$RUNNER_TEMP/zig-cache"
             export ZIG_LOCAL_CACHE_DIR="$RUNNER_TEMP/zig-cache"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  ZIG_VERSION: 0.16.0
+  ZIG_SHA256: 70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
+
 jobs:
   publish-binaries:
     name: Publish binaries
@@ -31,6 +35,30 @@ jobs:
               NAME: aarch64-linux,
               RUNNER: ubuntu-24.04-arm,
               TARGET: aarch64-unknown-linux-musl,
+            }
+          - {
+              NAME: riscv64-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: riscv64gc-unknown-linux-musl,
+              ZIGTARGET: riscv64-linux-musl,
+            }
+          - {
+              NAME: loongarch64-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: loongarch64-unknown-linux-musl,
+              ZIGTARGET: loongarch64-linux-musl,
+            }
+          - {
+              NAME: ppc64-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: powerpc64-unknown-linux-musl,
+              ZIGTARGET: powerpc64-linux-musl,
+            }
+          - {
+              NAME: ppc64le-linux,
+              RUNNER: ubuntu-latest,
+              TARGET: powerpc64le-unknown-linux-musl,
+              ZIGTARGET: powerpc64le-linux-musl,
             }
     steps:
       - name: Checkout
@@ -52,8 +80,44 @@ jobs:
           targets: ${{ matrix.build.TARGET }}
           components: rust-src
 
+      - name: Install zig
+        if: ${{ matrix.build.ZIGTARGET }}
+        run: |
+          curl -fL --retry 3 -o "$RUNNER_TEMP/zig.tar.xz" \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
+          echo "${ZIG_SHA256}  $RUNNER_TEMP/zig.tar.xz" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
+
+      - name: Create zig cc wrappers
+        if: ${{ matrix.build.ZIGTARGET }}
+        run: |
+          # cc-rs appends a rustc triple as --target=, which zig cc cannot
+          # parse, so the wrapper drops it and keeps the zig target
+          cat > "$RUNNER_TEMP/zigcc" <<EOF
+          #!/bin/bash
+          args=()
+          for a in "\$@"; do
+            case "\$a" in --target=*) ;; *) args+=("\$a") ;; esac
+          done
+          exec "$RUNNER_TEMP/zig/zig" cc -target ${{ matrix.build.ZIGTARGET }} "\${args[@]}"
+          EOF
+          printf '#!/bin/bash\nexec "%s" ar "$@"\n' "$RUNNER_TEMP/zig/zig" > "$RUNNER_TEMP/zigar"
+          chmod +x "$RUNNER_TEMP/zigcc" "$RUNNER_TEMP/zigar"
+
       - name: Build
-        run: cargo build --release --locked --target ${{ matrix.build.TARGET }} -Z build-std=std,panic_abort
+        run: |
+          if [ -n "${{ matrix.build.ZIGTARGET }}" ]; then
+            TARGET_ENV=$(echo "${{ matrix.build.TARGET }}" | tr 'a-z-' 'A-Z_')
+            CC_ENV=$(echo "${{ matrix.build.TARGET }}" | tr '-' '_')
+            export CARGO_TARGET_${TARGET_ENV}_LINKER="$RUNNER_TEMP/zigcc"
+            export CC_${CC_ENV}="$RUNNER_TEMP/zigcc"
+            export AR_${CC_ENV}="$RUNNER_TEMP/zigar"
+            export RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=no"
+            export ZIG_GLOBAL_CACHE_DIR="$RUNNER_TEMP/zig-cache"
+            export ZIG_LOCAL_CACHE_DIR="$RUNNER_TEMP/zig-cache"
+          fi
+          cargo build --release --locked --target ${{ matrix.build.TARGET }} -Z build-std=std,panic_abort
 
       - name: Prepare release assets
         shell: bash

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A Rust implementation of AppImageUpdate - a tool for updating AppImages using ef
 
 ## Installation
 
+### Prebuilt Binaries
+
+Every release ships static binaries for `x86_64`, `aarch64`, `riscv64`, `loongarch64`, `ppc64`, and `ppc64le` on the [releases page](https://github.com/pkgforge-dev/appimageupdate/releases). An installed copy can upgrade itself with `appimageupdate --self-update`.
+
 ### From Source
 
 ```bash

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -129,9 +129,17 @@ fn detect_arch() -> Result<&'static str> {
         Ok("x86_64")
     } else if cfg!(target_arch = "aarch64") {
         Ok("aarch64")
+    } else if cfg!(target_arch = "riscv64") {
+        Ok("riscv64")
+    } else if cfg!(target_arch = "loongarch64") {
+        Ok("loongarch64")
+    } else if cfg!(all(target_arch = "powerpc64", target_endian = "little")) {
+        Ok("ppc64le")
+    } else if cfg!(target_arch = "powerpc64") {
+        Ok("ppc64")
     } else {
         Err(Error::AppImage(
-            "--self-update only supports x86_64 and aarch64".into(),
+            "--self-update has no binary release for this architecture".into(),
         ))
     }
 }


### PR DESCRIPTION
Adds release binaries for `riscv64`, `loongarch64`, `ppc64`, and `ppc64le` on top of the existing `x86_64` and `aarch64` ones, cross-compiled with `zig cc` (pinned to zig 0.16.0 and checksum verified).

`--self-update` now resolves the asset name for the new architectures too.

Release builds also switch from `panic = "abort"` to `-C panic=immediate-abort`, which drops the panic formatting machinery. Panics now abort without a message.

| target | before | after | saved |
| --- | --- | --- | --- |
| x86_64 | 2.31 MiB | 1.89 MiB | 18% |
| riscv64 | 1.54 MiB | 1.25 MiB | 19% |
| loongarch64 | 1.78 MiB | 1.45 MiB | 18% |
| ppc64 | 1.99 MiB | 1.62 MiB | 18% |
| ppc64le | 1.98 MiB | 1.62 MiB | 18% |

Verified locally: all targets build with the exact workflow steps, and the big-endian `ppc64` binary runs correctly under qemu. The `aarch64` job builds natively on the arm runner and was not measured.