### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.4.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.3.2...0.4.0) - 2026-09-09
+
+### ⛰️  Features
+
+- Add a graphical mode ([#32](https://github.com/pkgforge-dev/AppImageUpdate/pull/32)) - ([999d5d6](https://github.com/pkgforge-dev/AppImageUpdate/commit/999d5d63065ce22ac08c50fcfc97a895ef24ccbb))
+
+### ⚙️ Miscellaneous Tasks
+
+- Build riscv64, loongarch64, and ppc64 releases ([#30](https://github.com/pkgforge-dev/AppImageUpdate/pull/30)) - ([7e1b1b3](https://github.com/pkgforge-dev/AppImageUpdate/commit/7e1b1b3611a76c23adaf83e61e1db6355fa0cb31))
+
 ## [0.3.2](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.3.1...0.3.2) - 2026-04-25
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "appimageupdate"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appimageupdate"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 description = "Fast, bandwidth-efficient AppImage updater using zsync"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `appimageupdate`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `appimageupdate` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:Aborted in /tmp/.tmpdDSk2Q/AppImageUpdate/src/error.rs:24
  variant Error:Aborted in /tmp/.tmpdDSk2Q/AppImageUpdate/src/error.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/pkgforge-dev/AppImageUpdate/compare/0.3.2...0.4.0) - 2026-09-09

### ⛰️  Features

- Add a graphical mode ([#32](https://github.com/pkgforge-dev/AppImageUpdate/pull/32)) - ([999d5d6](https://github.com/pkgforge-dev/AppImageUpdate/commit/999d5d63065ce22ac08c50fcfc97a895ef24ccbb))

### ⚙️ Miscellaneous Tasks

- Build riscv64, loongarch64, and ppc64 releases ([#30](https://github.com/pkgforge-dev/AppImageUpdate/pull/30)) - ([7e1b1b3](https://github.com/pkgforge-dev/AppImageUpdate/commit/7e1b1b3611a76c23adaf83e61e1db6355fa0cb31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).